### PR TITLE
Replaced lambda function by exported function in the module definition.

### DIFF
--- a/src/ng2-keycloak.module.ts
+++ b/src/ng2-keycloak.module.ts
@@ -5,18 +5,16 @@ import { Keycloak } from './services/keycloak.core.service';
 import { KeycloakAuthorization } from './services/keycloak.auth.service';
 import { KeycloakHttp } from './services/keycloak.http.service';
 
+export function keycloakHttpFactory(backend: XHRBackend, defaultOptions: RequestOptions, keycloakAuth: KeycloakAuthorization, keycloak: Keycloak) {
+    return new KeycloakHttp(backend, defaultOptions, keycloak, keycloakAuth);
+}
+
 @NgModule({
     imports: [ HttpModule ],
     declarations: [ ],
     providers: [Keycloak, KeycloakAuthorization, KeycloakHttp,
         {provide: Http,
-        useFactory:
-            (
-                backend: XHRBackend,
-                defaultOptions: RequestOptions,
-                keycloakAuth: KeycloakAuthorization,
-                keycloak: Keycloak
-            ) => new KeycloakHttp(backend, defaultOptions, keycloak,  keycloakAuth),
+        useFactory: keycloakHttpFactory,
         deps: [XHRBackend, RequestOptions, Keycloak, KeycloakAuthorization]
         }],
     exports:  [ ]


### PR DESCRIPTION
I noticed that some people (including me) have an error while using the module.

ERROR in Error encountered resolving symbol values statically. Function calls are not supported. Consider replacing the function or lambda with a reference to an exported function (position 25:11 in the original .ts file), resolving symbol Ng2KeycloakModule in [...]/ng2-keycloak.module.ts

Replacing the lambda by an exported function fixes the problem.