### PR TITLE
fix: Issue 22: Emit authentication pass with fragments, std flow, and iFrame

### DIFF
--- a/src/utils/keycloak.utils.URIParser.ts
+++ b/src/utils/keycloak.utils.URIParser.ts
@@ -98,10 +98,10 @@ export class URIParser {
       if (param) {
         switch (param) {
           case 'redirect_fragment':
-            oauth.fragment = param;
+            oauth.fragment = queryParams[param];
             break;
           case 'prompt':
-            oauth.prompt = param;
+            oauth.prompt = queryParams[param];
             break;
           default:
             if (

--- a/src/utils/keycloak.utils.URIParser.ts
+++ b/src/utils/keycloak.utils.URIParser.ts
@@ -126,7 +126,7 @@ export class URIParser {
       }
       for (const param in fragmentParams) {
         if (param) {
-          oauth[param] = param;
+          oauth[param] = fragmentParams[param];
         }
       }
     }


### PR DESCRIPTION
I'm currently attempting to use this library with the following init options:

```
   this.initOptions = {
      adapter: 'default',
      flow: 'standard',
      responseMode: 'fragment',
      checkLoginIframe: true,
      checkLoginIframeInterval: 5
    };

```
With the latest 0.9.1 release, I've no problem getting a call to login() to redirect to my authentication form and return with an access token, but the application never detects the successful authentication by firing true value down either authenticatedObs or authenticateSuccessObs.

Digging into the code a little bit, I tracked the problem into the URIParser utility used by the callback to extract the required input from the browser's current location. The "oauth" structure it returns currently looks like this:

```
{ 
    url: "http://www.foo.com/path/is/correct",
    state: "state",
    code: "code"
}
```

It looks like a fairly easily corrected error near the bottom of the URIParser file. In the loop where it is copying values from the hash of parsed fragment key/value pairs it is simply assigning the keys it is iterating over instead of their de-referenced values.

I hacked my workspace by changing line 126 of this block:

```
       for (const param in fragmentParams) {
           if (param) {
              oauth[param] = param;
           }
       }
```

... to copy the value for each required key instead of setting the key itself ...

```
       for (const param in fragmentParams) {
           if (param) {
                oauth[param] = fragmentParams[param];
           }
       }
```
