### PR TITLE
fix(interceptor): fix missing return in keycloak interceptor

### DIFF
--- a/projects/ebondu/angular-keycloak/package.json
+++ b/projects/ebondu/angular-keycloak/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ebondu/angular2-keycloak",
   "private": false,
-  "version": "1.6.1",
+  "version": "1.6.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/ebondu/angular2-keycloak.git"

--- a/projects/ebondu/angular-keycloak/src/lib/interceptor/keycloak.interceptor.ts
+++ b/projects/ebondu/angular-keycloak/src/lib/interceptor/keycloak.interceptor.ts
@@ -19,9 +19,9 @@
 import { Injectable, Injector } from '@angular/core';
 import { HttpErrorResponse, HttpEvent, HttpEventType, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 
-import { Observable, of, throwError } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { KeycloakService } from '../service/keycloak.service';
-import { catchError, filter, finalize, first, map, switchMap, tap } from 'rxjs/operators';
+import { catchError, filter, finalize, first, switchMap, tap } from 'rxjs/operators';
 
 @Injectable()
 export class KeycloakInterceptor implements HttpInterceptor {
@@ -106,14 +106,14 @@ export class KeycloakInterceptor implements HttpInterceptor {
                             );
                           }));
                       } else {
-                        throwError(error);
+                        return throwError(error);
                       }
                     } else {
                       // console.log('Error while calling endpoint', error);
-                      throwError(error);
+                      return throwError(error);
                     }
                   } else {
-                    throwError(error);
+                    return throwError(error);
                   }
                 }),
                 finalize(() => {


### PR DESCRIPTION
- avoid catchError in interceptor to provide undefined where a stream is expected
- remove unused import in keycloak interceptor file

When there is no return in catchError, catchError return an `undefined`, and [RxJS advice to always return an Observable from catchError()](https://www.learnrxjs.io/learn-rxjs/operators/error_handling/catch)