### PR TITLE
Fix NG0506 and bump to 1.8.2

### DIFF
--- a/projects/ebondu/angular-keycloak/package.json
+++ b/projects/ebondu/angular-keycloak/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ebondu/angular2-keycloak",
   "private": false,
-  "version": "1.8.1",
+  "version": "1.8.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/ebondu/angular2-keycloak.git"
@@ -23,8 +23,8 @@
     "tslib": "2.8.1"
   },
   "peerDependencies": {
-    "@angular/common": "^18.2.9 || ^19.0.0",
-    "@angular/core": "^18.2.9 || ^19.0.0",
+    "@angular/common": "^18.2.9 || ^19.0.0 || ^20.0.0",
+    "@angular/core": "^18.2.9 || ^19.0.0 || ^20.0.0",
     "uuid": "^10.0.0 || ^11.0.0",
     "js-sha256": "^0.11.0",
     "rxjs": "^7.8.1",

--- a/projects/ebondu/angular-keycloak/src/lib/service/keycloak.service.ts
+++ b/projects/ebondu/angular-keycloak/src/lib/service/keycloak.service.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { inject, Injectable, Injector, PLATFORM_ID } from '@angular/core';
+import { inject, Injectable, Injector, NgZone, PLATFORM_ID } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { BehaviorSubject, EMPTY, Observable, of } from 'rxjs';
 
@@ -89,6 +89,7 @@ export class KeycloakService {
 
   readonly #injector = inject(Injector);
   readonly #platformId = inject(PLATFORM_ID);
+  readonly #ngZone = inject(NgZone);
   readonly #configUrl = inject(KEYCLOAK_JSON_PATH, {optional: true});
   public keycloakConfig = inject(KEYCLOAK_CONF, {optional: true});
   public readonly initOptions = inject(KEYCLOAK_INIT_OPTIONS);
@@ -879,7 +880,15 @@ export class KeycloakService {
       const start = useTokenTime ? this.tokenParsed.iat : (new Date().getTime() / 1000);
       const expiresIn = this.tokenParsed.exp - start;
       this.tokenExpiredBS.next(false);
-      this.tokenTimeoutHandle = setTimeout(() => this.tokenExpiredBS.next(true), expiresIn * 1000);
+      // Run the timeout outside Angular Zone. (To prevent unstable application issue NG0506).
+      // Then update the observable inside Angular Zone (otherwise observable change is not detected)
+      this.#ngZone.runOutsideAngular(() => {
+        this.tokenTimeoutHandle = setTimeout(() => {
+          this.#ngZone.run(
+            () => this.tokenExpiredBS.next(true), expiresIn * 1000
+          );
+        });
+      });
     } else {
       delete this.accessToken;
       delete this.tokenParsed;


### PR DESCRIPTION
The setTimeout used inside the service by default runs inside the Angular Zone.
Thus it creates a macroTask inside ngZone.
However, the applicationRef.isStable does not emit true unless there is no macro task within the ng zone.
Which means that here it emit the stability once the token expires...
When using client hydration, after the redirection dues to login, the integrating application produces an error NG0506, stating that after 10 secondes the application is still not stable, and thus it does not start hydration.

The proposed solution is to ensure that the setTimeout is created outside the Angular zone, but then the observable next has to be called inside the zone to ensure it is ticked (in order to trigger change detection).