### PR TITLE
fix: Rethrow inner second error instead of first 401

### DIFF
--- a/projects/ebondu/angular-keycloak/package.json
+++ b/projects/ebondu/angular-keycloak/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ebondu/angular2-keycloak",
   "private": false,
-  "version": "1.8.5",
+  "version": "1.8.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/ebondu/angular2-keycloak.git"

--- a/projects/ebondu/angular-keycloak/src/lib/interceptor/keycloak.interceptor.ts
+++ b/projects/ebondu/angular-keycloak/src/lib/interceptor/keycloak.interceptor.ts
@@ -61,7 +61,7 @@ export const keycloakInterceptor: HttpInterceptorFn = (req: HttpRequest<unknown>
                 });
                 return next(rptReq);
               }),
-              catchError(() => throwError(() => error))
+              catchError((secondError: unknown) => throwError(() => secondError))
             );
           }
           return throwError(() => error);


### PR DESCRIPTION
Throw error caught from backend instead of the orignal 401

 - Also bump yo version 1.8.6